### PR TITLE
Kahina/storing commitment mongodb

### DIFF
--- a/nightfall_client/src/driven/db/mongo.rs
+++ b/nightfall_client/src/driven/db/mongo.rs
@@ -330,7 +330,7 @@ impl CommitmentDB<Fr254, CommitmentEntry> for Client {
     }
 
     async fn get_commitment(&self, k: &Fr254) -> Option<CommitmentEntry> {
-        let filter = doc! { "key": hex::encode(k.into_bigint().to_bytes_le()) };
+        let filter = doc! { "_id": hex::encode(k.into_bigint().to_bytes_le()) };
         self.database(DB)
             .collection::<CommitmentEntry>("commitments")
             .find_one(filter)
@@ -367,7 +367,7 @@ impl CommitmentDB<Fr254, CommitmentEntry> for Client {
             .into_iter()
             .map(|c| hex::encode(c.into_bigint().to_bytes_le()))
             .collect::<Vec<_>>();
-        let filter = doc! { "key": { "$in": commitment_str }};
+        let filter = doc! { "_id": { "$in": commitment_str }};
         let update = doc! {"$set": { "status": "PendingSpend" }};
         self.database(DB)
             .collection::<CommitmentEntry>("commitments")
@@ -382,7 +382,7 @@ impl CommitmentDB<Fr254, CommitmentEntry> for Client {
             .into_iter()
             .map(|c| hex::encode(c.into_bigint().to_bytes_le()))
             .collect::<Vec<_>>();
-        let filter = doc! { "key": { "$in": commitment_str }};
+        let filter = doc! { "_id": { "$in": commitment_str }};
         let update = doc! {"$set": { "status": "PendingCreation" }};
         self.database(DB)
             .collection::<CommitmentEntry>("commitments")
@@ -421,7 +421,7 @@ impl CommitmentDB<Fr254, CommitmentEntry> for Client {
             .collect::<Vec<_>>();
         let l1_hash = l1_hash.map(|h| h.encode_hex());
         let l2_blocknumber = l2_blocknumber.map(|b| b.encode_hex());
-        let filter = doc! { "key": { "$in": commitment_str }};
+        let filter = doc! { "_id": { "$in": commitment_str }};
         let update = doc! {"$set": { "status": "Unspent", "layer_1_transaction_hash": l1_hash, "layer_2_block_number": l2_blocknumber }};
         self.database(DB)
             .collection::<CommitmentEntry>("commitments")
@@ -433,7 +433,7 @@ impl CommitmentDB<Fr254, CommitmentEntry> for Client {
 
     // we compute a nullifier for each spend commitment that we process.
     async fn add_nullifier(&self, key: &Fr254, nullifier: Fr254) -> Option<()> {
-        let filter = doc! { "key": hex::encode(key.into_bigint().to_bytes_le())};
+        let filter = doc! { "_id": hex::encode(key.into_bigint().to_bytes_le())};
         let update =
             doc! {"$set": { "nullifier": hex::encode(nullifier.into_bigint().to_bytes_le()) }};
 

--- a/nightfall_client/src/driven/db/mongo.rs
+++ b/nightfall_client/src/driven/db/mongo.rs
@@ -469,7 +469,7 @@ impl CommitmentDB<Fr254, CommitmentEntry> for Client {
         }
     }
 
-    /// function to store multiple commitments in the database, optionally ignoring duplicate key errors
+    /// function to store multiple commitments in the database, optionally ignoring duplicate _id errors
     async fn store_commitments(
         &self,
         commitments: &[CommitmentEntry],
@@ -485,13 +485,13 @@ impl CommitmentDB<Fr254, CommitmentEntry> for Client {
             .await;
         match res {
             Ok(_) => Some(()),
-            // unpack the Mongo error and check if it's a duplicate key error. If so, behave according to dup_key_check
+            // unpack the Mongo error and check if it's a duplicate _id error. If so, behave according to dup_key_check
             Err(e) => {
                 match e.kind.as_ref() {
                     ErrorKind::Write(WriteError(write_error)) => {
                         if write_error.code == 11000 && !dup_key_check {
-                            println!("Duplicate key error: {:?}", write_error);
-                            // duplicate key error but we don't care
+                            println!("Duplicate _id error: {:?}", write_error);
+                            // duplicate _id error but we don't care
                             Some(())
                         } else {
                             None

--- a/nightfall_client/src/driven/db/mongo.rs
+++ b/nightfall_client/src/driven/db/mongo.rs
@@ -164,7 +164,8 @@ impl From<DBMembershipProof> for MembershipProof<Fr254> {
 pub struct CommitmentEntry {
     pub preimage: Preimage,
     pub status: CommitmentStatus,
-    #[serde(serialize_with = "ark_se_hex", deserialize_with = "ark_de_hex")]
+    
+    #[serde(rename = "_id",serialize_with = "ark_se_hex", deserialize_with = "ark_de_hex")]
     pub key: Fr254,
     #[serde(
         serialize_with = "ark_se_hex",
@@ -203,7 +204,8 @@ impl Commitment for CommitmentEntry {
     }
 }
 impl CommitmentEntryDB for CommitmentEntry {
-    fn new(preimage: Preimage, key: Fr254, nullifier: Fr254, status: CommitmentStatus) -> Self {
+    fn new(preimage: Preimage, nullifier: Fr254, status: CommitmentStatus) -> Self {
+        let key = preimage.hash().expect("failed to hash preimage");
         Self {
             preimage,
             status,
@@ -443,7 +445,10 @@ impl CommitmentDB<Fr254, CommitmentEntry> for Client {
         Some(())
     }
 
-    async fn store_commitment(&self, commitment: CommitmentEntry) -> Option<()> {
+    async fn store_commitment(
+        &self, 
+        commitment: CommitmentEntry
+    ) -> Option<()> {
         let result = self
             .database(DB)
             .collection::<CommitmentEntry>("commitments")

--- a/nightfall_client/src/driven/event_handlers/nightfall_event.rs
+++ b/nightfall_client/src/driven/event_handlers/nightfall_event.rs
@@ -336,7 +336,6 @@ async fn process_propose_block_event<N: NightfallContract>(
                 .map_err(|_| EventHandlerError::HashError)?;
             let commitment_entry = CommitmentEntry::new(
                 test_preimage,
-                commitment_hash,
                 nullifier,
                 CommitmentStatus::Unspent,
             );

--- a/nightfall_client/src/driven/event_handlers/nightfall_event.rs
+++ b/nightfall_client/src/driven/event_handlers/nightfall_event.rs
@@ -323,13 +323,6 @@ async fn process_propose_block_event<N: NightfallContract>(
             debug!("Commitment {} is not owned by us", commitment_hash);
         } else {
             info!("Received commitment owned by us, with hash {}", test_hash);
-            // We can transfer to ourselves, so we need to check if we already have the commitment in our database
-            let found_commitment = db.get_commitment(&commitment_hash).await;
-            if found_commitment.is_some() {
-                debug!("Commitment {} already in database", commitment_hash);
-                // If we already have the commitment, we don't need to do anything
-                continue;
-            }
             // store our newly received commitment in our commitment db
             let nullifier = test_preimage
                 .nullifier_hash(&nullifier_key)

--- a/nightfall_client/src/drivers/rest/client_nf_3.rs
+++ b/nightfall_client/src/drivers/rest/client_nf_3.rs
@@ -398,7 +398,6 @@ pub async fn handle_deposit<N: NightfallContract>(
     let commitment_hash = preimage_value.hash().expect("Could not hash commitment");
     let commitment_entry = CommitmentEntry::new(
         preimage_value,
-        commitment_hash,
         nullifier,
         CommitmentStatus::PendingCreation,
     );
@@ -432,7 +431,6 @@ pub async fn handle_deposit<N: NightfallContract>(
 
         let commitment_entry = CommitmentEntry::new(
             preimage_fee,
-            commitment_hash,
             nullifier,
             CommitmentStatus::PendingCreation,
         );

--- a/nightfall_client/src/drivers/rest/client_operation.rs
+++ b/nightfall_client/src/drivers/rest/client_operation.rs
@@ -84,7 +84,6 @@ where
                     .expect("Nullifiers must be hashable");
                 let commitment_entry = CommitmentEntry::new(
                     commitment.get_preimage(),
-                    commitment_hash,
                     nullifier,
                     CommitmentStatus::PendingCreation,
                 );

--- a/nightfall_client/src/ports/db.rs
+++ b/nightfall_client/src/ports/db.rs
@@ -41,7 +41,7 @@ where
 }
 
 pub trait CommitmentEntryDB: Commitment {
-    fn new(preimage: Preimage, key: Fr254, nullifier: Fr254, status: CommitmentStatus) -> Self;
+    fn new(preimage: Preimage, nullifier: Fr254, status: CommitmentStatus) -> Self;
     fn get_status(&self) -> CommitmentStatus;
 }
 

--- a/nightfall_client/src/services/commitment_selection.rs
+++ b/nightfall_client/src/services/commitment_selection.rs
@@ -249,12 +249,14 @@ async fn verify_enough_commitments(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::domain::entities::CommitmentStatus;
     use ark_bn254::Fr as Fr254;
     use testcontainers::{
         core::IntoContainerPort, runners::AsyncRunner, ContainerAsync, GenericImage,
     };
     use tokio::io::AsyncReadExt;
     use url::Host;
+    
 
     fn get_db_connection_uri(host: Host, port: u16) -> String {
         format!("mongodb://{}:{}", host, port)
@@ -293,81 +295,93 @@ mod test {
             let database = db.database("nightfall");
             let commitments_collection = database.collection::<CommitmentEntry>("commitments");
 
-            let commitments = vec![
-                CommitmentEntry {
-                    preimage: Preimage {
-                        value: Fr254::from(1u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
-                        value: Fr254::from(2u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
-                        value: Fr254::from(3u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
-                        value: Fr254::from(4u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
-                        value: Fr254::from(1u64),
-                        nf_token_id: Fr254::from(2u64), // fee commitment
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
-                        value: Fr254::from(2u64),
-                        nf_token_id: Fr254::from(2u64), // fee commitment
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
-                        value: Fr254::from(5u64),
-                        nf_token_id: Fr254::from(2u64), // fee commitment
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
-                        value: Fr254::from(3u64),
-                        nf_token_id: Fr254::from(2u64), // Fee commitment
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
-                        value: Fr254::from(6u64),
-                        nf_token_id: Fr254::from(2u64), // Fee commitment
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-            ];
-
+            
+let commitments = vec![
+    // Value commitments for nf_token_id: 1
+    CommitmentEntry::new(
+        Preimage {
+            value: Fr254::from(1u64),
+            nf_token_id: Fr254::from(1u64),
+            ..Default::default()
+        },
+        Fr254::default(),
+        CommitmentStatus::Unspent,
+    ),
+    CommitmentEntry::new(
+        Preimage {
+            value: Fr254::from(2u64),
+            nf_token_id: Fr254::from(1u64),
+            ..Default::default()
+        },
+        Fr254::default(),
+        CommitmentStatus::Unspent,
+    ),
+    CommitmentEntry::new(
+        Preimage {
+            value: Fr254::from(3u64),
+            nf_token_id: Fr254::from(1u64),
+            ..Default::default()
+        },
+        Fr254::default(),
+        CommitmentStatus::Unspent,
+    ),
+    CommitmentEntry::new(
+        Preimage {
+            value: Fr254::from(4u64),
+            nf_token_id: Fr254::from(1u64),
+            ..Default::default()
+        },
+        Fr254::default(),
+        CommitmentStatus::Unspent,
+    ),
+    // Fee commitments for nf_token_id: 2
+    CommitmentEntry::new(
+        Preimage {
+            value: Fr254::from(1u64),
+            nf_token_id: Fr254::from(2u64),
+            ..Default::default()
+        },
+        Fr254::default(),
+        CommitmentStatus::Unspent,
+    ),
+    CommitmentEntry::new(
+        Preimage {
+            value: Fr254::from(2u64),
+            nf_token_id: Fr254::from(2u64),
+            ..Default::default()
+        },
+        Fr254::default(),
+        CommitmentStatus::Unspent,
+    ),
+    CommitmentEntry::new(
+        Preimage {
+            value: Fr254::from(5u64),
+            nf_token_id: Fr254::from(2u64),
+            ..Default::default()
+        },
+        Fr254::default(),
+        CommitmentStatus::Unspent,
+    ),
+    CommitmentEntry::new(
+        Preimage {
+            value: Fr254::from(3u64),
+            nf_token_id: Fr254::from(2u64),
+            ..Default::default()
+        },
+        Fr254::default(),
+        CommitmentStatus::Unspent,
+    ),
+    CommitmentEntry::new(
+        Preimage {
+            value: Fr254::from(6u64),
+            nf_token_id: Fr254::from(2u64),
+            ..Default::default()
+        },
+        Fr254::default(),
+        CommitmentStatus::Unspent,
+    ),
+];
+            // Insert the commitments into the database
             commitments_collection
                 .insert_many(commitments)
                 .await
@@ -446,36 +460,41 @@ mod test {
             let commitments_collection = database.collection::<CommitmentEntry>("commitments");
 
             let commitments = vec![
-                CommitmentEntry {
-                    preimage: Preimage {
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(5u64),
                         nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(6u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
+                        nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(7u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
+                        nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
             ];
+
 
             commitments_collection
                 .insert_many(commitments)
                 .await
                 .expect("Failed to insert commitments into the database");
+    
         }
 
         // Call the function under test
@@ -531,62 +550,69 @@ mod test {
                     },
                     ..Default::default()
                 },
-                CommitmentEntry {
-                    preimage: Preimage {
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(6u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
+                        nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(7u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
+                        nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(5u64),
                         nf_token_id: Fr254::from(2u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(6u64),
                         nf_token_id: Fr254::from(2u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(12u64),
                         nf_token_id: Fr254::from(2u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(2u64),
                         nf_token_id: Fr254::from(2u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(13u64),
                         nf_token_id: Fr254::from(2u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
             ];
 
             commitments_collection
@@ -661,30 +687,33 @@ mod test {
             let commitments_collection = database.collection::<CommitmentEntry>("commitments");
 
             let commitments = vec![
-                CommitmentEntry {
-                    preimage: Preimage {
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(5u64),
                         nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(6u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
+                        nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(7u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
+                        nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
             ];
 
             commitments_collection
@@ -728,30 +757,33 @@ mod test {
             let commitments_collection = database.collection::<CommitmentEntry>("commitments");
 
             let commitments = vec![
-                CommitmentEntry {
-                    preimage: Preimage {
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(5u64),
                         nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(6u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
+                        nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-                CommitmentEntry {
-                    preimage: Preimage {
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
+                CommitmentEntry::new(
+                    Preimage {
                         value: Fr254::from(7u64),
-                        nf_token_id: Fr254::from(1u64), // Value commitment
+                        nf_token_id: Fr254::from(1u64),
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
+                    Fr254::default(),
+                    CommitmentStatus::Unspent,
+                ),
             ];
 
             commitments_collection

--- a/nightfall_client/src/test_helpers/mocks.rs
+++ b/nightfall_client/src/test_helpers/mocks.rs
@@ -57,7 +57,7 @@ impl MockCommitmentEntry {
     }
 }
 impl CommitmentEntryDB for MockCommitmentEntry {
-    fn new(preimage: Preimage, _key: Fr254, nullifier: Fr254, status: CommitmentStatus) -> Self {
+    fn new(preimage: Preimage, nullifier: Fr254, status: CommitmentStatus) -> Self {
         Self {
             preimage,
             nullifier,


### PR DESCRIPTION
MongoDB was automatically generating unique _id fields for CommitmentEntry, even when commitment was identical. This allowed duplicate commitments to be inserted into the db, bypassing the intended uniqueness constraint.

Solution
We now explicitly map the key field  which is the hash of the preimage and acts as the natural unique identifier  to MongoDB’s _id field