### PR TITLE
chore: fixed yml

### DIFF
--- a/doc/Setup Testnet Guide.md
+++ b/doc/Setup Testnet Guide.md
@@ -202,9 +202,9 @@ curl -v [host-chain]-configuration_url:8080/<key_name> -o configuration/bin/keys
 ```
 where you need to it for following keys `base_bn254_pk`, `base_grumpkin_pk`, `decider_pk`, `merge_bn254_pk_0`, `merge_grumpkin_pk_0`, `merge_grumpkin_pk_1`, and `proving_key`. use `ls -lh`to check the key size, it should match the size mentioned before.
 
-2. `curl [host-chain]-configuration_url/configuration/toml/addresses.toml` to get addresses for `nightfall`, `round_robin`, `x509` and `verifier`.
+2. `curl [host-chain]-configuration_url:8080/configuration/toml/addresses.toml` to get addresses for `nightfall`, `round_robin`, `x509` and `verifier`.
 
-3. `curl [host-chain]-configuration_url/configuration/toml/contract_hashes.toml` to get contract hashes for `nightfall_hash`, `round_robin_hash`, `x509_hash`.
+3. `curl [host-chain]-configuration_url:8080/configuration/toml/contract_hashes.toml` to get contract hashes for `nightfall_hash`, `round_robin_hash`, `x509_hash`.
 
 
 ------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -431,14 +431,8 @@ services:
     volumes:
       - ./blockchain_assets/test_contracts:/test_contracts
       - ./blockchain_assets/logs:/app/blockchain_assets/logs # to be able to see deployed contract addresses locally
-      - type: volume
-        source: key_data
-        target: /app/configuration/bin/keys
-        read_only: false
-      - type: volume
-        source: toml_data
-        target: /app/configuration/toml
-        read_only: false
+      - ./configuration/bin/keys:/app/configuration/bin/keys:ro
+      - ./configuration/toml:/app/configuration/toml
     stdin_open: true # keep stdin open, so we can print things in docker compose up
     tty: true # required for logs to print in colour
     environment:
@@ -466,14 +460,8 @@ services:
     #   - "8080:80"     replace with a port that is exposed for configuration service if required
     platform: linux/amd64 # Required for building on M1 Macs
     volumes:
-      - type: volume
-        source: toml_data
-        target: /var/www/html/configuration/toml
-        read_only: true
-      - type: volume
-        source: key_data
-        target: /var/www/html/configuration/bin/keys
-        read_only: true
+      - ./configuration/toml:/var/www/html/configuration/toml
+      - ./configuration/bin/keys:/var/www/html/configuration/bin/keys:ro
     networks:
       - nightfall_network
     stdin_open: true # keep stdin open, so we can print things in docker compose up


### PR DESCRIPTION
This PR updates the Docker Compose configuration to use local bind mounts for configuration files instead of Docker-managed named volumes.

## Changes

- Mounts `./configuration/bin/keys` into the `indie-deployer` and `configuration` services.
- Mounts `./configuration/toml` into the `indie-deployer` and `configuration` services.
- Keeps key files read-only inside the containers.
- Ensures local configuration changes are reflected directly in the relevant containers.
<img width="2470" height="1862" alt="image" src="https://github.com/user-attachments/assets/bd30ef6b-31fb-4d01-b834-90eb3975a566" />

